### PR TITLE
chore: fix multi-instances error

### DIFF
--- a/src/services/hcaptcha_challenger/core.py
+++ b/src/services/hcaptcha_challenger/core.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import time
+import random
 import urllib.request
 from typing import Optional, Union, Tuple
 
@@ -131,7 +132,7 @@ class ArmorCaptcha:
     def _init_workspace(self):
         """初始化工作目录，存放缓存的挑战图片"""
         _prefix = (
-            f"{int(time.time())}" + f"_{self.label_alias.get(self.label, '')}" if self.label else ""
+            f"{int(time.time())}" + f"_{random.randint(100000, 999999)}" + f"_{self.label_alias.get(self.label, '')}" if self.label else ""
         )
         _workspace = os.path.join(self.dir_workspace, _prefix)
         if not os.path.exists(_workspace):

--- a/src/services/hcaptcha_challenger/core.py
+++ b/src/services/hcaptcha_challenger/core.py
@@ -3,7 +3,6 @@ import os
 import re
 import sys
 import time
-import random
 import urllib.request
 from typing import Optional, Union, Tuple
 
@@ -132,7 +131,7 @@ class ArmorCaptcha:
     def _init_workspace(self):
         """初始化工作目录，存放缓存的挑战图片"""
         _prefix = (
-            f"{int(time.time())}" + f"_{random.randint(100000, 999999)}" + f"_{self.label_alias.get(self.label, '')}" if self.label else ""
+            f"{time.time()}" + f"_{self.label_alias.get(self.label, '')}" if self.label else ""
         )
         _workspace = os.path.join(self.dir_workspace, _prefix)
         if not os.path.exists(_workspace):


### PR DESCRIPTION
When using multiple instances of the challenger it will glitch after some time when trying to create 2 workspaces with the same name, because they're generated at the same timespan. Adding a random number to the workspace directory when creating it will decrease significantly the odds of this happen.