### PR TITLE
Linux: allow headful operation if X11 present

### DIFF
--- a/hcaptcha_challenger/_scaffold/__init__.py
+++ b/hcaptcha_challenger/_scaffold/__init__.py
@@ -135,7 +135,13 @@ def get_challenge_ctx(
     :rtype: uc.Chrome
     """
     # Control headless browser
-    silence = True if silence is None or "linux" in sys.platform else silence
+    # If on Linux, and no X server is available (`DISPLAY` not set), assume
+    # headless operation
+    silence = (
+        True
+        if silence is None or ("linux" in sys.platform and "DISPLAY" not in os.environ)
+        else silence
+    )
 
     # - Restrict browser startup parameters
     options = uc.ChromeOptions()


### PR DESCRIPTION
Don't prevent headful operation on Linux if X11 is present (`DISPLAY` env var is set). Fixes #466.