### PR TITLE
mode fix

### DIFF
--- a/hcaptcha_challenger/agents/playwright/control.py
+++ b/hcaptcha_challenger/agents/playwright/control.py
@@ -57,7 +57,7 @@ class QuestionResp:
     request_type: str = ""
     """
     1. image_label_binary
-    2. image_label_area_select  
+    2. image_label_area_select
     """
 
     requester_question: Dict[str, str] = field(default_factory=dict)
@@ -268,7 +268,7 @@ class Radagon:
     def _download_images(self):
         request_type = self.qr.request_type
         self.typed_dir = self.tmp_dir.joinpath(request_type, self._label)
-        self.typed_dir.mkdir(mode=777, parents=True, exist_ok=True)
+        self.typed_dir.mkdir(mode=0o777, parents=True, exist_ok=True)
 
         # Prelude container
         container = []

--- a/hcaptcha_challenger/agents/skeleton.py
+++ b/hcaptcha_challenger/agents/skeleton.py
@@ -160,7 +160,7 @@ class Skeleton(ABC):
         if self._label:
             prefix = f"{time.time()}_{self._label_alias.get(self._label, self._label)}"
         runtime_dir = self.challenge_dir.joinpath(prefix)
-        runtime_dir.mkdir(mode=777, parents=True, exist_ok=True)
+        runtime_dir.mkdir(mode=0o777, parents=True, exist_ok=True)
 
         # Initialize the data container
         container = []

--- a/hcaptcha_challenger/onnx/modelhub.py
+++ b/hcaptcha_challenger/onnx/modelhub.py
@@ -95,7 +95,7 @@ class Assets:
 
     def __post_init__(self):
         for ck in [self._assets_dir, self._memory_dir]:
-            ck.mkdir(mode=777, parents=True, exist_ok=True)
+            ck.mkdir(mode=0o777, parents=True, exist_ok=True)
 
     @classmethod
     def from_release_url(cls, release_url: str, **kwargs):
@@ -134,7 +134,7 @@ class Assets:
         if upgrade is True:
             logger.info("Reloading the local cache of Assets", assets_dir=str(self._assets_dir))
             shutil.rmtree(self._assets_dir, ignore_errors=True)
-            self._assets_dir.mkdir(mode=777, parents=True, exist_ok=True)
+            self._assets_dir.mkdir(mode=0o777, parents=True, exist_ok=True)
 
         assets_paths = [self._assets_dir.joinpath(i) for i in os.listdir(self._assets_dir)]
         is_outdated = False
@@ -233,7 +233,7 @@ class ModelHub:
     """
 
     def __post_init__(self):
-        self.assets_dir.mkdir(mode=777, parents=True, exist_ok=True)
+        self.assets_dir.mkdir(mode=0o777, parents=True, exist_ok=True)
 
     @classmethod
     def from_github_repo(cls, username: str = "QIN2DIM", lang: str = "en", **kwargs):


### PR DESCRIPTION
The unix mode number must be expressed as an octal. I tried running the demos, and due to the modes being some bogus numbers, it would create folders as "dr----x--t", which after some more time, would crash the program with permission denied. This fixes it.