### PR TITLE
Add DISABLE_HSW_REVERSE to environment examples

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -6,6 +6,11 @@ GEMINI_API_KEY=
 # Default: false
 DISABLE_BEZIER_TRAJECTORY=false
 
+# Force disable HSW reverse engineering and fallback to visual recognition. Useful for testing the
+# fallback branch when HSW decoding fails.
+# Default: false
+DISABLE_HSW_REVERSE=false
+
 # CRUMB_COUNT: The number of challenge rounds you need to solve once the challenge starts.
 # In the vast majority of cases this value will be 2, some specialized sites will set this value to 3.
 # In most cases you don't need to change this value, the `_review_challenge_type` task determines the

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -6,6 +6,11 @@ GEMINI_API_KEY=
 # Default: false
 DISABLE_BEZIER_TRAJECTORY=false
 
+# Force disable HSW reverse engineering and fallback to visual recognition. Useful for testing the
+# fallback branch when HSW decoding fails.
+# Default: false
+DISABLE_HSW_REVERSE=false
+
 # CRUMB_COUNT: The number of challenge rounds you need to solve once the challenge starts.
 # In the vast majority of cases this value will be 2, some specialized sites will set this value to 3.
 # In most cases you don't need to change this value, the `_review_challenge_type` task determines the


### PR DESCRIPTION
Added DISABLE_HSW_REVERSE configuration option to docker and examples .env.example files with documentation explaining its use for testing HSW fallback behavior.